### PR TITLE
Optim enhance

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,5 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test code
       run: |
-        # python -m unittest discover -s tests
-        python -m unittest tests.test_ergm.TestERGM.test_assigning_model_initial_thetas
+        python -m unittest discover -s tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,4 +36,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test code
       run: |
-        python -m unittest discover -s tests
+        # python -m unittest discover -s tests
+        python -m unittest tests.test_ergm.TestERGM.test_assigning_model_initial_thetas

--- a/ClusterScripts/distributed_binomial_tensor_statistics.sh
+++ b/ClusterScripts/distributed_binomial_tensor_statistics.sh
@@ -1,6 +1,6 @@
 #BSUB -q short
 #BSUB -R "span[hosts=1]"
-#BSUB -R rusage[mem=1000]
+#BSUB -R rusage[mem=4000]
 #BSUB -o ../logs/intermediate_calcs/outs.%J.%I.log
 #BSUB -e ../logs/intermediate_calcs/errors.%J.%I.error.log
 #BSUB -C 1

--- a/ClusterScripts/distributed_logistic_regression.sh
+++ b/ClusterScripts/distributed_logistic_regression.sh
@@ -1,6 +1,6 @@
 #BSUB -q short
 #BSUB -R "span[hosts=1]"
-#BSUB -R rusage[mem=1000]
+#BSUB -R rusage[mem=4000]
 #BSUB -o ../logs/intermediate_calcs/outs.%J.%I.log
 #BSUB -e ../logs/intermediate_calcs/errors.%J.%I.error.log
 #BSUB -C 1

--- a/logistic_regression_distributed_calcs.py
+++ b/logistic_regression_distributed_calcs.py
@@ -13,6 +13,7 @@ def parse_cmd_args():
     parser.add_argument('--out_dir_path', type=str)
     parser.add_argument('--num_edges_per_job', type=int)
     parser.add_argument('--function', type=str)
+    # TODO: it seems like the parser doesn't know to deal with scientific format (e.g. -3.243718829521125e-05).
     parser.add_argument('--thetas', action=StoreNpArr, type=float, nargs='+')
     args = parser.parse_args()
     return args

--- a/logistic_regression_distributed_calcs.py
+++ b/logistic_regression_distributed_calcs.py
@@ -1,5 +1,5 @@
 import argparse
-from utils import *
+from pyERGM.utils import *
 
 
 class StoreNpArr(argparse._StoreAction):
@@ -12,6 +12,7 @@ def parse_cmd_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--out_dir_path', type=str)
     parser.add_argument('--num_edges_per_job', type=int)
+    parser.add_argument('--function', type=str)
     parser.add_argument('--thetas', action=StoreNpArr, type=float, nargs='+')
     args = parser.parse_args()
     return args
@@ -21,6 +22,7 @@ def main():
     args = parse_cmd_args()
     out_dir_path = args.out_dir_path
     num_edges_per_job = args.num_edges_per_job
+    func_to_calc = args.function
     thetas = args.thetas
     thetas = thetas[:, None]
     func_id = int(os.environ['LSB_JOBINDEX']) - 1
@@ -29,35 +31,31 @@ def main():
     with open(os.path.join(out_dir_path, 'data', 'observed_network.pkl'), 'rb') as f:
         observed_network = pickle.load(f)
 
-    # Get data chunk
+    # Get data chunk and predictions
     num_nodes = observed_network.shape[0]
     edge_indices = (func_id * num_edges_per_job,
                     min((func_id + 1) * num_edges_per_job, num_nodes * num_nodes - num_nodes))
     Xs_chunk, ys_chunk = metric_collection.prepare_mple_data(observed_network, edge_indices)
-
-    # Calculate a chunk of the predictions and store it
     chunk_prediction = calc_logistic_regression_predictions(Xs_chunk, thetas)
-    predictions_dir_path = os.path.join(out_dir_path, "prediction")
-    os.makedirs(predictions_dir_path, exist_ok=True)
-    with open(os.path.join(predictions_dir_path, f'{func_id}.pkl'), 'wb') as f:
-        pickle.dump(chunk_prediction, f)
+
+    # Create outputs directory to store the calculated chunks
+    chunks_dir_path = os.path.join(out_dir_path, func_to_calc)
+    os.makedirs(chunks_dir_path, exist_ok=True)
 
     # Calculate the contributions of the chunk to the log-likelihood, the gradient and the hessian.
-    chunk_log_like = calc_logistic_regression_predictions_log_likelihood(chunk_prediction, ys_chunk)
-    log_likes_dir_path = os.path.join(out_dir_path, "log_like")
-    os.makedirs(log_likes_dir_path, exist_ok=True)
-    with open(os.path.join(log_likes_dir_path, f'{func_id}.pkl'), 'wb') as f:
-        pickle.dump(chunk_log_like, f)
-    chunk_grad = calc_logistic_regression_log_likelihood_grad(Xs_chunk, chunk_prediction, ys_chunk)
-    grad_dir_path = os.path.join(out_dir_path, "grad")
-    os.makedirs(grad_dir_path, exist_ok=True)
-    with open(os.path.join(grad_dir_path, f'{func_id}.pkl'), 'wb') as f:
-        pickle.dump(chunk_grad, f)
-    chunk_hessian = calc_logistic_regression_log_likelihood_hessian(Xs_chunk, chunk_prediction)
-    hessian_dir_path = os.path.join(out_dir_path, "hessian")
-    os.makedirs(hessian_dir_path, exist_ok=True)
-    with open(os.path.join(hessian_dir_path, f'{func_id}.pkl'), 'wb') as f:
-        pickle.dump(chunk_hessian, f)
+    if func_to_calc == 'log_likelihood':
+        func_chunk = calc_logistic_regression_predictions_log_likelihood(chunk_prediction, ys_chunk)
+    elif func_to_calc == 'log_likelihood_gradient':
+        func_chunk = calc_logistic_regression_log_likelihood_grad(Xs_chunk, chunk_prediction, ys_chunk)
+    elif func_to_calc == 'log_likelihood_hessian':
+        func_chunk = calc_logistic_regression_log_likelihood_hessian(Xs_chunk, chunk_prediction)
+    else:
+        raise ValueError(f'Unsupported function to calculate for logistic regression distributed '
+                         f'optimization: {func_to_calc}. Possibilities are: '
+                         f'log_likelihood, log_likelihood_gradient, log_likelihood_hessian')
+
+    with open(os.path.join(chunks_dir_path, f'{func_id}.pkl'), 'wb') as f:
+        pickle.dump(func_chunk, f)
 
 
 if __name__ == "__main__":

--- a/logistic_regression_distributed_calcs.py
+++ b/logistic_regression_distributed_calcs.py
@@ -43,7 +43,9 @@ def main():
     os.makedirs(chunks_dir_path, exist_ok=True)
 
     # Calculate the contributions of the chunk to the log-likelihood, the gradient and the hessian.
-    if func_to_calc == 'log_likelihood':
+    if func_to_calc == 'predictions':
+        func_chunk = chunk_prediction
+    elif func_to_calc == 'log_likelihood':
         func_chunk = calc_logistic_regression_predictions_log_likelihood(chunk_prediction, ys_chunk)
     elif func_to_calc == 'log_likelihood_gradient':
         func_chunk = calc_logistic_regression_log_likelihood_grad(Xs_chunk, chunk_prediction, ys_chunk)
@@ -52,7 +54,7 @@ def main():
     else:
         raise ValueError(f'Unsupported function to calculate for logistic regression distributed '
                          f'optimization: {func_to_calc}. Possibilities are: '
-                         f'log_likelihood, log_likelihood_gradient, log_likelihood_hessian')
+                         f'predictions, log_likelihood, log_likelihood_gradient, log_likelihood_hessian')
 
     with open(os.path.join(chunks_dir_path, f'{func_id}.pkl'), 'wb') as f:
         pickle.dump(func_chunk, f)

--- a/pyERGM/ergm.py
+++ b/pyERGM/ergm.py
@@ -139,7 +139,7 @@ class ERGM():
             return True
         return False
 
-    def _mple_fit(self, observed_network, lr=0.001, stopping_thr: float = 1e-6, logistic_reg_max_iter=1000):
+    def _mple_fit(self, observed_network):
         """
         Perform MPLE estimation of the ERGM parameters.
         This is done by fitting a logistic regression model, where the X values are the change statistics
@@ -159,16 +159,10 @@ class ERGM():
         thetas: np.ndarray
             The estimated coefficients of the ERGM.
         """
-        print(f"MPLE with lr {lr}")
-        # trained_thetas, prediction = mple_logistic_regression_optimization(self._metrics_collection, observed_network,
-        #                                                                    is_distributed=self._is_distributed_optimization,
-        #                                                                    lr=lr,
-        #                                                                    stopping_thr=stopping_thr,
-        #                                                                    max_iter=logistic_reg_max_iter)
-
-        trained_thetas, prediction = scipy_mple_logistic_regression_optimization(self._metrics_collection,
-                                                                                 observed_network,
-                                                                                 is_distributed=self._is_distributed_optimization)
+        print("MPLE")
+        trained_thetas, prediction = mple_logistic_regression_optimization(self._metrics_collection,
+                                                                           observed_network,
+                                                                           is_distributed=self._is_distributed_optimization)
 
         self._exact_average_mat = np.zeros((self._n_nodes, self._n_nodes))
 
@@ -219,9 +213,6 @@ class ERGM():
             mcmc_seed_network=None,
             mcmc_steps_per_sample=10,
             mcmc_sample_size=100,
-            mple_lr=1,
-            mple_stopping_thr=1e-6,
-            mple_max_iter=1000,
             edge_proposal_method='uniform',
             **kwargs
             ):
@@ -307,15 +298,6 @@ class ERGM():
         
         mcmc_sample_size : int
             Optional. The number of networks to sample with the MCMC sampler. *Defaults to 100*.
-        
-        mple_lr : float
-            Optional. The learning rate for the logistic regression model in the MPLE step. *Defaults to 0.001*.
-        
-        mple_stopping_thr : float
-            Optional. The stopping threshold for the logistic regression model in the MPLE step. *Defaults to 1e-6*.
-        
-        mple_max_iter : int
-            Optional. The maximum number of iterations for the logistic regression model in the MPLE step. *Defaults to 1000*.
 
         edge_proposal_method : str
             Optional. The method for the MCMC proposal distribution. This is defined as a distribution over the edges
@@ -336,8 +318,7 @@ class ERGM():
             print(f"Using existing thetas")
             pass
         elif not no_mple and self._do_MPLE(theta_init_method):
-            self._thetas = self._mple_fit(observed_network, lr=mple_lr, stopping_thr=mple_stopping_thr,
-                                          logistic_reg_max_iter=mple_max_iter)
+            self._thetas = self._mple_fit(observed_network)
 
             if not self._metrics_collection._has_dyadic_dependent_metrics:
                 print(f"Model is dyadic independent - using only MPLE instead of MCMLE")

--- a/pyERGM/ergm.py
+++ b/pyERGM/ergm.py
@@ -139,7 +139,7 @@ class ERGM():
             return True
         return False
 
-    def _mple_fit(self, observed_network):
+    def _mple_fit(self, observed_network, optimization_method: str = 'L-BFGS-B'):
         """
         Perform MPLE estimation of the ERGM parameters.
         This is done by fitting a logistic regression model, where the X values are the change statistics
@@ -162,7 +162,8 @@ class ERGM():
         print("MPLE")
         trained_thetas, prediction = mple_logistic_regression_optimization(self._metrics_collection,
                                                                            observed_network,
-                                                                           is_distributed=self._is_distributed_optimization)
+                                                                           is_distributed=self._is_distributed_optimization,
+                                                                           optimization_method=optimization_method)
 
         self._exact_average_mat = np.zeros((self._n_nodes, self._n_nodes))
 
@@ -318,7 +319,8 @@ class ERGM():
             print(f"Using existing thetas")
             pass
         elif not no_mple and self._do_MPLE(theta_init_method):
-            self._thetas = self._mple_fit(observed_network)
+            self._thetas = self._mple_fit(observed_network,
+                                          optimization_method=kwargs.get('mple_optimization_method', 'L-BFGS-B'))
 
             if not self._metrics_collection._has_dyadic_dependent_metrics:
                 print(f"Model is dyadic independent - using only MPLE instead of MCMLE")

--- a/pyERGM/ergm.py
+++ b/pyERGM/ergm.py
@@ -70,6 +70,9 @@ class ERGM():
                                                          'num_samples_per_job_collinearity_fixer', 5))
 
         if initial_thetas is not None:
+            if type(initial_thetas) != dict:
+                raise ValueError("Initial thetas must be a dictionary keyed by feature names, as returned by "
+                                 "`ERGM.get_model_parameters`")
             self._thetas = np.zeros(self._metrics_collection.calc_num_of_features())
             current_model_params = self.get_model_parameters()
             if len(set(initial_thetas.keys()).difference(set(current_model_params.keys()))) > 0:
@@ -695,12 +698,16 @@ class BruteForceERGM(ERGM):
 
     def fit(self, observed_network):
         def nll(thetas):
-            model = BruteForceERGM(self._n_nodes, list(self._metrics_collection.metrics), initial_thetas=thetas,
+            model = BruteForceERGM(self._n_nodes, list(self._metrics_collection.metrics),
+                                   initial_thetas={feat_name: thetas[i] for i, feat_name in
+                                                   enumerate(self._metrics_collection.get_parameter_names())},
                                    is_directed=self._is_directed)
             return np.log(model._normalization_factor) - np.log(model.calculate_weight(observed_network))
 
         def nll_grad(thetas):
-            model = BruteForceERGM(self._n_nodes, list(self._metrics_collection.metrics), initial_thetas=thetas,
+            model = BruteForceERGM(self._n_nodes, list(self._metrics_collection.metrics),
+                                   initial_thetas={feat_name: thetas[i] for i, feat_name in
+                                                   enumerate(self._metrics_collection.get_parameter_names())},
                                    is_directed=self._is_directed)
             observed_features = model._metrics_collection.calculate_statistics(observed_network)
             all_probs = model._all_weights / model._normalization_factor

--- a/pyERGM/ergm.py
+++ b/pyERGM/ergm.py
@@ -66,7 +66,7 @@ class ERGM():
                                                      fix_collinearity=fix_collinearity,
                                                      collinearity_fixer_sample_size=collinearity_fixer_sample_size,
                                                      is_collinearity_distributed=self._is_distributed_optimization,
-                                                     num_samples_per_job=kwargs.get(
+                                                     num_samples_per_job_collinearity_fixer=kwargs.get(
                                                          'num_samples_per_job_collinearity_fixer', 5))
 
         if initial_thetas is not None:

--- a/pyERGM/metrics.py
+++ b/pyERGM/metrics.py
@@ -941,7 +941,8 @@ class MetricsCollection:
                  collinearity_fixer_sample_size=1000,
                  is_collinearity_distributed=False,
                  # TODO: For tests only, find a better solution
-                 do_copy_metrics=True):
+                 do_copy_metrics=True,
+                 **kwargs):
 
         if not do_copy_metrics:
             self.metrics = tuple([metric for metric in metrics])
@@ -969,7 +970,8 @@ class MetricsCollection:
         self.collinearity_fixer_sample_size = collinearity_fixer_sample_size
         if self._fix_collinearity:
             self.collinearity_fixer(sample_size=self.collinearity_fixer_sample_size,
-                                    is_distributed=is_collinearity_distributed)
+                                    is_distributed=is_collinearity_distributed,
+                                    num_samples_per_job=kwargs.get('num_samples_per_job_collinearity_fixer', 5))
 
         # Returns the number of features that are being calculated. Since a single metric might return more than one
         # feature, the length of the statistics vector might be larger than the amount of metrics. Since it also depends
@@ -1078,7 +1080,7 @@ class MetricsCollection:
         return whole_sample_statistics
 
     def collinearity_fixer(self, sample_size=1000, nonzero_thr=10 ** -1, ratio_threshold=10 ** -6,
-                           eigenvec_thr=10 ** -4, is_distributed=False):
+                           eigenvec_thr=10 ** -4, is_distributed=False, **kwargs):
         """
         Find collinearity between metrics in the collection.
 
@@ -1094,7 +1096,9 @@ class MetricsCollection:
         if not is_distributed:
             sample_features = self.calc_statistics_for_binomial_tensor_local(sample_size)
         else:
-            sample_features = self.calc_statistics_for_binomial_tensor_distributed(sample_size, num_samples_per_job=5)
+            sample_features = self.calc_statistics_for_binomial_tensor_distributed(sample_size,
+                                                                                   num_samples_per_job=kwargs.get(
+                                                                                       "num_samples_per_job", 5))
         while is_linearly_dependent:
             self.num_of_features = self.calc_num_of_features()
 

--- a/pyERGM/utils.py
+++ b/pyERGM/utils.py
@@ -638,7 +638,8 @@ def analytical_minus_log_likelihood_local(thetas, Xs, ys, eps=1e-10):
 def numerically_stable_minus_log_like_and_grad_local(thetas, Xs, ys):
     linear_pred = Xs @ thetas
 
-    # Magic numbers are taken from sklearn
+    # Magic numbers are taken from sklearn:
+    # https://github.com/scikit-learn/scikit-learn/blob/72b35a46684c0ecf4182500d3320836607d1f17c/sklearn/_loss/_loss.pyx.tp#L728
     rng_1_idx = np.where(linear_pred <= -37)[0]
     rng_2_idx = np.where((-37 < linear_pred) & (linear_pred <= -2))[0]
     rng_3_idx = np.where((-2 < linear_pred) & (linear_pred <= 18))[0]

--- a/pyERGM/utils.py
+++ b/pyERGM/utils.py
@@ -690,7 +690,7 @@ def analytical_minus_log_like_grad_local(thetas, Xs, ys, eps=1e-10):
 def analytical_minus_log_like_grad_distributed(thetas, data_path, num_edges_per_job):
     return -distributed_logistic_regression_optimization_step(data_path, thetas.reshape(thetas.size, 1),
                                                               'log_likelihood_gradient',
-                                                              num_edges_per_job)
+                                                              num_edges_per_job).reshape(thetas.size, )
 
 
 def analytical_minus_log_likelihood_hessian_local(thetas, Xs, ys, eps=1e-10):

--- a/pyERGM/utils.py
+++ b/pyERGM/utils.py
@@ -3,7 +3,6 @@ from collections import Counter
 from typing import Collection
 import numpy as np
 import networkx as nx
-from PIL.GimpGradientFile import linear
 from numba import njit, objmode
 from scipy.spatial.distance import mahalanobis
 from scipy.optimize import minimize, OptimizeResult

--- a/pyERGM/utils.py
+++ b/pyERGM/utils.py
@@ -841,7 +841,7 @@ def _construct_single_batch_bash_cmd_logistic_regression(out_path, cur_thetas, f
     cmd_line_for_bsub = (f'python ./logistic_regression_distributed_calcs.py '
                          f'--out_dir_path {out_path} '
                          f'--num_edges_per_job {num_edges_per_job} '
-                         f'--function {func_to_calculate}'
+                         f'--function {func_to_calculate} '
                          f'--thetas {thetas_str}')
     return cmd_line_for_bsub
 

--- a/pyERGM/utils.py
+++ b/pyERGM/utils.py
@@ -637,6 +637,8 @@ def analytical_minus_log_likelihood_local(thetas, Xs, ys, eps=1e-10):
 @njit
 def numerically_stable_minus_log_like_and_grad_local(thetas, Xs, ys):
     linear_pred = Xs @ thetas
+
+    # Magic numbers are taken from sklearn
     rng_1_idx = np.where(linear_pred <= -37)[0]
     rng_2_idx = np.where((-37 < linear_pred) & (linear_pred <= -2))[0]
     rng_3_idx = np.where((-2 < linear_pred) & (linear_pred <= 18))[0]

--- a/sample_statistics_distributed_calcs.py
+++ b/sample_statistics_distributed_calcs.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from utils import *
+from pyERGM.utils import *
 
 
 def parse_cmd_args():

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -15,7 +15,8 @@ class TestERGM(unittest.TestCase):
         self.thetas = np.ones(MetricsCollection(self.metrics, is_directed=False, n_nodes=self.n_nodes).num_of_features)
 
     def test_calculate_weight(self):
-        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=self.thetas, initial_normalization_factor=self.K)
+        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=self.thetas,
+                    initial_normalization_factor=self.K)
 
         W = np.array([[0, 1, 1],
                       [1, 0, 1],
@@ -40,7 +41,8 @@ class TestERGM(unittest.TestCase):
         self.assertEqual(weight, expected_weight)
 
     def test_calculate_probability(self):
-        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=self.thetas, initial_normalization_factor=self.K)
+        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=self.thetas,
+                    initial_normalization_factor=self.K)
 
         W = np.array([[0, 1, 1],
                       [1, 0, 1],
@@ -58,7 +60,8 @@ class TestERGM(unittest.TestCase):
         thetas = [-np.log(2), np.log(3)]
         K = 29 / 8
 
-        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=thetas, initial_normalization_factor=K)
+        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=thetas,
+                    initial_normalization_factor=K)
 
         W_0_edges = np.array([[0, 0, 0],
                               [0, 0, 0],
@@ -343,3 +346,28 @@ class TestERGM(unittest.TestCase):
         # 0.56682151])
 
         # self.assertAlmostEqual()
+
+    def test_assigning_model_initial_thetas(self):
+        np.random.seed(8765)
+        n_nodes = 5
+        W = np.array([[0, 0, 1, 1, 0],
+                      [1, 0, 0, 0, 1],
+                      [0, 0, 0, 0, 1],
+                      [0, 1, 0, 0, 0],
+                      [0, 1, 0, 1, 0]])
+        metrics_1 = [NumberOfEdgesDirected(), NodeAttrSum(np.arange(1, n_nodes + 1), is_directed=True),
+                     NumberOfEdgesTypesDirected(['A', 'B', 'A', 'A', 'B'])]
+        model_1 = ERGM(n_nodes=n_nodes, metrics_collection=metrics_1, is_directed=True)
+
+        model_1.fit(W)
+
+        model_1_params = model_1.get_model_parameters()
+
+        metrics_2 = [NumberOfEdgesDirected(), NodeAttrSum(np.arange(n_nodes + 1, 1, -1), is_directed=True),
+                     NumberOfEdgesTypesDirected(['B', 'B', 'B', 'A', 'A'])]
+        model_2 = ERGM(n_nodes=n_nodes, metrics_collection=metrics_2, is_directed=True, initial_thetas=model_1_params)
+
+        expected_model_1_params = np.array(
+            [-0.5479023176512173, -0.02727153085065387, 0.022474879697902, 0.022461903905710654,
+             18.45553104887986])
+        self.assertTrue(np.all(np.abs(model_2._thetas - expected_model_1_params) < 1e-10))

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -373,6 +373,10 @@ class TestERGM(unittest.TestCase):
         expected_model_1_params = np.array(
             [-0.5479023176512173, -0.02727153085065387, 0.022474879697902, 0.022461903905710654,
              18.45553104887986])
+        print("#########")
+        print(model_2._thetas)
+        print("#########")
+        print(np.abs(model_2._thetas - expected_model_1_params))
         self.assertTrue(np.all(np.abs(model_2._thetas - expected_model_1_params) < 1e-10))
 
     def test_calculate_prediction(self):

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -12,7 +12,7 @@ class TestERGM(unittest.TestCase):
         self.n_nodes = 3
 
         self.K = 100
-        self.thetas = np.ones(MetricsCollection(self.metrics, is_directed=False, n_nodes=self.n_nodes).num_of_features)
+        self.thetas = {str(m): 1 for m in self.metrics}
 
     def test_calculate_weight(self):
         ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=self.thetas,
@@ -60,7 +60,8 @@ class TestERGM(unittest.TestCase):
         thetas = [-np.log(2), np.log(3)]
         K = 29 / 8
 
-        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False, initial_thetas=thetas,
+        ergm = ERGM(self.n_nodes, self.metrics, is_directed=False,
+                    initial_thetas={str(m): thetas[i] for i, m in enumerate(self.metrics)},
                     initial_normalization_factor=K)
 
         W_0_edges = np.array([[0, 0, 0],
@@ -138,7 +139,8 @@ class TestERGM(unittest.TestCase):
 
         number_of_edges_metric = NumberOfEdgesDirected() if is_directed else NumberOfEdgesUndirected()
         model_with_true_theta = BruteForceERGM(n, [number_of_edges_metric],
-                                               initial_thetas=np.array(ground_truth_theta), is_directed=is_directed)
+                                               initial_thetas={str(number_of_edges_metric): ground_truth_theta[0]},
+                                               is_directed=is_directed)
 
         ground_truth_model_log_like = np.log(model_with_true_theta.calculate_weight(adj_mat)) - np.log(
             model_with_true_theta._normalization_factor)

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -348,6 +348,7 @@ class TestERGM(unittest.TestCase):
         # self.assertAlmostEqual()
 
     def test_assigning_model_initial_thetas(self):
+        # TODO: seems like convergence of the model in this test depends on the seed...
         np.random.seed(8765)
         n_nodes = 5
         W = np.array([[0, 0, 1, 1, 0],

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -234,3 +234,112 @@ class TestERGM(unittest.TestCase):
 
         for inferred_proba, real_density in zip(inferred_probas_per_type_pairs, real_densities_per_type):
             self.assertAlmostEqual(inferred_proba, real_density, places=4)
+
+    def test_MPLE_regressors_of_different_scales(self):
+        # TODO: currently this is a smoke test - we validate nothing: neither convergence nor the thetas/predictions.
+        #  Somehow sklearn still finds a slightly better solution than ours.
+        np.random.seed(42)
+
+        W = np.random.randint(0, 2, size=(10, 10))
+        W[np.diag_indices(10)] = 0
+
+        metrics = [NumberOfEdgesDirected(),
+                   NodeAttrSum([np.random.randint(1, 5) ** 10 for x in range(10)], is_directed=True)]
+        model = ERGM(n_nodes=10, metrics_collection=metrics, is_directed=True)
+
+        model.fit(W)
+
+        # sklearn_thetas = np.array([2.82974701e-01, -2.34383474e-07])
+
+        # sklearn_probas = np.array([0.56682151,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.56682151,
+        # 0.56347922,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.44804742,
+        # 0.5092404 ,
+        # 0.50584116,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.44804742,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.5092404 ,
+        # 0.50584116,
+        # 0.56682151,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.57015772,
+        # 0.5092404 ,
+        # 0.56682151,
+        # 0.56347922,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.56682151,
+        # 0.50584116,
+        # 0.56682151])
+
+        # self.assertAlmostEqual()

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -370,14 +370,7 @@ class TestERGM(unittest.TestCase):
                      NumberOfEdgesTypesDirected(['B', 'B', 'B', 'A', 'A'])]
         model_2 = ERGM(n_nodes=n_nodes, metrics_collection=metrics_2, is_directed=True, initial_thetas=model_1_params)
 
-        expected_model_1_params = np.array(
-            [-0.5479023176512173, -0.02727153085065387, 0.022474879697902, 0.022461903905710654,
-             18.45553104887986])
-        print("#########")
-        print(model_2._thetas)
-        print("#########")
-        print(np.abs(model_2._thetas - expected_model_1_params))
-        self.assertTrue(np.all(np.abs(model_2._thetas - expected_model_1_params) < 1e-10))
+        self.assertTrue(model_2.get_model_parameters() == model_1_params)
 
     def test_calculate_prediction(self):
         n_nodes = 4

--- a/tests/test_ergm.py
+++ b/tests/test_ergm.py
@@ -371,3 +371,21 @@ class TestERGM(unittest.TestCase):
             [-0.5479023176512173, -0.02727153085065387, 0.022474879697902, 0.022461903905710654,
              18.45553104887986])
         self.assertTrue(np.all(np.abs(model_2._thetas - expected_model_1_params) < 1e-10))
+
+    def test_calculate_prediction(self):
+        n_nodes = 4
+        W = np.array([[0, 1, 0, 1],
+                      [0, 0, 1, 1],
+                      [1, 0, 0, 0],
+                      [0, 0, 1, 0]])
+
+        metrics = [NumberOfEdgesDirected()]
+        model = ERGM(n_nodes=n_nodes, metrics_collection=metrics, is_directed=True)
+        model.fit(W)
+
+        model_2 = ERGM(n_nodes=n_nodes, metrics_collection=metrics, is_directed=True,
+                       initial_thetas=model.get_model_parameters())
+        model_2_av_mat = model_2.get_mple_prediction(W)
+        expected_model_2_av_mat = 0.5 * np.ones((n_nodes, n_nodes))
+        expected_model_2_av_mat[np.diag_indices(n_nodes)] = 0
+        self.assertTrue(np.abs(model_2_av_mat - expected_model_2_av_mat).max() < 1e-10)


### PR DESCRIPTION
* Implemented a numerical stable version for the loss and gradient of Logistic Regression, used during MPLE optimization.
Magic numbers are taken from `sklearn`:
https://github.com/scikit-learn/scikit-learn/blob/72b35a46684c0ecf4182500d3320836607d1f17c/sklearn/_loss/_loss.pyx.tp#L728
This solves the scaling problem we had (more robust to different scales of regressors).
* Transitioned to `scipy.optimize.minimize` for Logistic Regression optimization (rather than the custom optimization loop we had).
* Changed `initial_thetas` to be a dictionary (rather than a `np.ndarray`), like what is returned from `ERGM.get_model_parameters()`. Now given parameters are aligned according to the keys in the dictionary, rather than position in the array, the `collinearity_fixer` doesn't run for models that are initialized with parameters, and redundant features are removed from 'ergm._metrics_collection` on init (features that are missing in the received dictionary of initial parameters).
* Added a method `ERGM.get_mple_prediction` that serves as a getter for `ERGM._exact_average_matrix`. It calculates the MPLE prediction if the matrix doesn't exist (`ERGM._mple` didn't run). For dyadic dependent models, where the MPLE prediction is an estimation that depends on the `observed_network` provided, the prediction is calculated every time.
* Distributed MPLE prediction is not working properly, probably due to parameter parsing issues.