### PR TITLE
`NumberOfEdgesRefactor`

### DIFF
--- a/pyERGM/metrics.py
+++ b/pyERGM/metrics.py
@@ -206,7 +206,9 @@ class NumberOfEdges(Metric):
         """
         A getter to normalize calculations for directed/undirected graphs in children classes
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            "This class is abstract by nature, please use either NumberOfEdgesUndirected or NumberOfEdgesDirected"
+        )
 
     def calculate(self, W: np.ndarray):
         return np.sum(W) // self._get_num_edges_in_mat_factor()


### PR DESCRIPTION
- Add a class `NumberOfEdges` that is the parent of `NumberOfEdgesDirected` and `NumberOfEdgesUndirected` and holds the shared implementation for the 2 subclasses.
-  In particular -  streamline the calculation of MPLE regressors in the case of undirected networks.